### PR TITLE
feat: implement markdown copy and toast notifications (#5)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,7 @@
   /* アニメーション設定 */
   --animate-spin: spin 1s linear infinite;
   --animate-fade-in: fade-in 0.2s ease-in-out;
+  --animate-slide-in-bottom: slide-in-bottom 0.3s ease-out;
 
   @keyframes spin {
     from {
@@ -30,6 +31,17 @@
     to {
       opacity: 1;
       transform: scale(1);
+    }
+  }
+
+  @keyframes slide-in-bottom {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
     }
   }
 }

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import type React from "react";
+import { useEffect } from "react";
+
+export type ToastType = "success" | "error" | "info";
+
+export interface ToastProps {
+  message: string;
+  type?: ToastType;
+  duration?: number;
+  onClose: () => void;
+  className?: string;
+}
+
+const TOAST_STYLES: Record<ToastType, string> = {
+  success: "bg-green-500 text-white",
+  error: "bg-red-500 text-white",
+  info: "bg-blue-500 text-white",
+};
+
+const TOAST_ICONS: Record<ToastType, React.ReactElement> = {
+  success: (
+    <svg
+      className="h-5 w-5"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <title>成功</title>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M5 13l4 4L19 7"
+      />
+    </svg>
+  ),
+  error: (
+    <svg
+      className="h-5 w-5"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <title>エラー</title>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M6 18L18 6M6 6l12 12"
+      />
+    </svg>
+  ),
+  info: (
+    <svg
+      className="h-5 w-5"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <title>情報</title>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  ),
+};
+
+export function Toast({
+  message,
+  type = "info",
+  duration = 3000,
+  onClose,
+  className = "",
+}: ToastProps) {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onClose();
+    }, duration);
+
+    return () => clearTimeout(timer);
+  }, [duration, onClose]);
+
+  return (
+    <div
+      className={`fixed bottom-4 right-4 z-50 flex items-center gap-3 rounded-lg px-4 py-3 shadow-lg transition-all duration-300 animate-slide-in-bottom ${TOAST_STYLES[type]} ${className}`}
+      role="alert"
+      aria-live="polite"
+    >
+      <div className="flex-shrink-0">{TOAST_ICONS[type]}</div>
+      <p className="text-sm font-medium">{message}</p>
+      <button
+        type="button"
+        onClick={onClose}
+        className="ml-2 flex-shrink-0 rounded-full p-1 hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
+        aria-label="閉じる"
+      >
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <title>閉じる</title>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { ToastType } from "@/components/ui/Toast";
+
+export interface ToastMessage {
+  id: string;
+  message: string;
+  type: ToastType;
+  duration?: number;
+}
+
+export interface UseToastResult {
+  toasts: ToastMessage[];
+  showToast: (message: string, type?: ToastType, duration?: number) => void;
+  hideToast: (id: string) => void;
+  clearToasts: () => void;
+}
+
+/**
+ * Hook for managing toast notifications
+ */
+export function useToast(): UseToastResult {
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+
+  const showToast = useCallback(
+    (message: string, type: ToastType = "info", duration = 3000) => {
+      const id = `toast-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+      const toast: ToastMessage = { id, message, type, duration };
+
+      setToasts((prev) => [...prev, toast]);
+    },
+    [],
+  );
+
+  const hideToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  const clearToasts = useCallback(() => {
+    setToasts([]);
+  }, []);
+
+  return {
+    toasts,
+    showToast,
+    hideToast,
+    clearToasts,
+  };
+}

--- a/src/lib/image-processor.ts
+++ b/src/lib/image-processor.ts
@@ -190,6 +190,24 @@ export async function copyImageToClipboard(blob: Blob): Promise<void> {
 }
 
 /**
+ * Copy markdown text to clipboard
+ * Format: ![LGTM](imageUrl)
+ */
+export async function copyMarkdownToClipboard(imageUrl: string): Promise<void> {
+  try {
+    if (!navigator.clipboard || !navigator.clipboard.writeText) {
+      throw new Error("Clipboard API not supported");
+    }
+
+    const markdown = `![LGTM](${imageUrl})`;
+    await navigator.clipboard.writeText(markdown);
+  } catch (error) {
+    console.error("Error copying markdown to clipboard:", error);
+    throw new Error("マークダウンのコピーに失敗しました");
+  }
+}
+
+/**
  * Download image as file
  */
 export function downloadImage(blob: Blob, filename = "lgtm.png"): void {


### PR DESCRIPTION
## Summary
Closes #5

Implemented markdown copy functionality and toast notification system for LGTM image operations.

### Key Features
- ✅ Markdown format copy: `![LGTM](imageUrl)`
- ✅ Toast notifications (green for success, red for error)
- ✅ Auto-dismiss after 3 seconds (configurable)
- ✅ Accessible with proper ARIA labels
- ✅ Smooth slide-in animations

### Implementation Details

**1. Markdown Copy Functionality** ([src/lib/image-processor.ts](src/lib/image-processor.ts#L192-L208))
- Added `copyMarkdownToClipboard` function
  - Format: `![LGTM](imageUrl)`
  - Uses Clipboard API `writeText` method
  - Proper error handling with user-friendly messages

**2. Enhanced useLGTM Hook** ([src/hooks/useLGTM.ts](src/hooks/useLGTM.ts))
- Added `originalImageUrl` state to track image source URL
- Added `copyMarkdown` method for markdown text copy
- Separated concerns: `copyImageToClipboard` for image, `copyMarkdown` for text
- Both methods properly integrated with error handling

**3. Toast Notification System**
- Created **Toast Component** ([src/components/ui/Toast.tsx](src/components/ui/Toast.tsx))
  - Three variants: success (green), error (red), info (blue)
  - Auto-dismiss timer (default: 3000ms)
  - Manual close button
  - Slide-in-bottom animation
  - Fully accessible with ARIA attributes
  - Icons for each toast type
  
- Created **useToast Hook** ([src/hooks/useToast.ts](src/hooks/useToast.ts))
  - Toast state management
  - `showToast(message, type, duration)` method
  - `hideToast(id)` method for manual dismissal
  - `clearToasts()` to remove all toasts
  - Unique ID generation for each toast

**4. UI Integration** ([src/app/search/page.tsx](src/app/search/page.tsx))
- Replaced all `alert()` calls with toast notifications
- Success toast on markdown copy: "マークダウンをコピーしました！"
- Success toast on download: "画像をダウンロードしました！"
- Error toasts for failures with descriptive messages
- Updated filename format: `lgtm-{timestamp}.png`
- Toast container renders at bottom-right of screen

**5. Animations** ([src/app/globals.css](src/app/globals.css#L37-L46))
- Added `slide-in-bottom` keyframe animation
- Smooth 300ms ease-out transition
- Translates from 20px below to final position

### Technical Specifications
- **Toast Position**: Fixed bottom-right (bottom-4 right-4)
- **Toast Duration**: 3 seconds (configurable per toast)
- **Animation**: Slide-in from bottom with opacity fade
- **Z-Index**: 50 (ensures visibility above modals)
- **Accessibility**: Proper ARIA roles and labels

### Browser Compatibility
- Clipboard API required (all modern browsers)
- HTTPS required for clipboard access in production
- Graceful error handling for unsupported browsers

## Test plan
- [x] Build passes without errors
- [x] Biome linting passes
- [ ] Manual testing: Copy markdown and verify format
- [ ] Manual testing: Verify toast notifications appear and auto-dismiss
- [ ] Manual testing: Verify success toasts are green
- [ ] Manual testing: Verify error toasts are red
- [ ] Manual testing: Test manual toast dismissal
- [ ] Manual testing: Test multiple simultaneous toasts
- [ ] Manual testing: Verify ARIA accessibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)